### PR TITLE
Add support for Tiny, Heroku and Google stacks

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,4 +21,10 @@ api = "0.2"
   id = "io.paketo.stacks.tiny"
 
 [[stacks]]
+  id = "heroku-20"
+
+[[stacks]]
+  id = "google"
+
+[[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,4 +18,7 @@ api = "0.2"
   id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
+  id = "io.paketo.stacks.tiny"
+
+[[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"


### PR DESCRIPTION
The `io.paketo.stacks.tiny` [supports](https://github.com/paketo-buildpacks/base-stack-release/blob/main/build-receipt) Git, which should be all that's necessary for this buildpack.